### PR TITLE
Migrated to API v2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-  "manifest_version": "2",
-  "api_version": "1",
+  "required_api_version": "^2.0.0",
   "name": "DevDocs",
   "description": "Search on DevDocs from Ulauncher",
   "developer_name": "Bruno Paz",
@@ -8,7 +7,8 @@
   "options": {
     "query_debounce": 0.5
   },
-  "preferences": [{
+  "preferences": [
+    {
       "id": "keyword",
       "type": "keyword",
       "name": "DevDocs",
@@ -45,16 +45,12 @@
       "default_value": "ruby~2.5"
     },
     {
-      "id": "open_doc_in", 
+      "id": "open_doc_in",
       "type": "select",
       "name": "Open Documentation on",
       "description": "Indicates in which application you want to open the selected doc.",
       "default_value": "Browser",
-      "options": [
-        "Browser",
-        "Hawkeye",
-        "DevDocs Protocol"
-      ]
+      "options": ["Browser", "Hawkeye", "DevDocs Protocol"]
     }
   ]
 }

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,10 @@
+[
+  {
+    "required_api_version": "^1.0.0",
+    "commit": "api-v1-release"
+  },
+  {
+    "required_api_version": "^2.0.0",
+    "commit": "master"
+  }
+]


### PR DESCRIPTION
I've added branch `api-v1-release`, as per ulaunchers migration guide. It's identical to the previous master (API v1).
Please do a `git fetch git@github.com:therj/ulauncher-devdocs.git api-v1-release:api-v1-release`.