### PR TITLE
fix: Parses docs prefs as JSON, python version fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ class DevdocsExtension(Extension):
 
         # initialize DevDocs service.
         self.devdocs_svc = DevDocsService(LOGGING,
-                                          os.path.join(CACHE_DIR, 'devdocs'))
+                                          os.path.join(CACHE_PATH, 'devdocs'))
 
     def index_docs(self):
         """ Creates a local index of all the DevDocs resources """

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from ulauncher.api.shared.action.OpenAction import OpenAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.action.RunScriptAction import RunScriptAction
 from ulauncher.api.shared.action.ExtensionCustomAction import ExtensionCustomAction
-from ulauncher.config import CACHE_DIR
+from ulauncher.utils.migrate import CACHE_PATH
 from devdocs.devdocs_service import DevDocsService
 
 gi.require_version('Notify', '0.7')


### PR DESCRIPTION
Fixes #7 
- Parses docs as JSON before it's passed to set_docs_to_fetch()
  - Fixes the issue of random languages getting indexed
    - E.G.: If you put "markdown" and it parses it as a string, it also indexes
      D and R docs
- Devdocs uses versions (python~3.13) for python, so added fallback for when a user enters
just "python"