### PR TITLE
feat: Added generalised version matching for docs that require it

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ class DevdocsExtension(Extension):
 
         # initialize DevDocs service.
         self.devdocs_svc = DevDocsService(LOGGING,
-                                          os.path.join(CACHE_DIR, 'devdocs'))
+                                          os.path.join(CACHE_PATH, 'devdocs'))
 
     def index_docs(self):
         """ Creates a local index of all the DevDocs resources """

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from ulauncher.api.shared.action.OpenAction import OpenAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.action.RunScriptAction import RunScriptAction
 from ulauncher.api.shared.action.ExtensionCustomAction import ExtensionCustomAction
-from ulauncher.config import CACHE_DIR
+from ulauncher.utils.migrate import CACHE_PATH
 from devdocs.devdocs_service import DevDocsService
 
 gi.require_version('Notify', '0.7')


### PR DESCRIPTION
Building on the Python versioning fallback, added a generalised way to deal with
versioned docs (E.g: Python~3.13, gcc~14), and defaults to latest version is
none is provided by the user. Uses regex matching to split between name and version.